### PR TITLE
chore: Drop 8080 from exposed ports

### DIFF
--- a/setup
+++ b/setup
@@ -64,7 +64,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "8080:8080" # The Web UI (enabled by --api)
     networks:
       - traefik
     volumes:
@@ -201,6 +200,8 @@ rm -Rf /tmp/traefik-proxy
 set +x
 echo
 echo "Traefik proxy setup"
+echo
+echo "To view the dashboard, open https://traefik.dev.localhost"
 echo
 echo "To proxy an image add the container to the \`${network_name}\` network, and add the minimal"
 echo "labels…"


### PR DESCRIPTION
This is the port for accessing the Traefik dashboard, however this is exposed via Trafik labels at https://traefik.dev.localhost, so the direct port access is not required.

Also added a link to the dashboard to the information echoed at the end of the setup script.