### PR TITLE
feat: Traefik v3.6.8 upgrade, local CA cert chain, Taskfile

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,1 +1,2 @@
 FQDN=dev.localhost
+TRAEFIK_VERSION=3.6.8

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,67 @@
+version: '3'
+
+vars:
+  TRAEFIK_VERSION:
+    sh: grep traefik_version bin/build.sh | head -1 | cut -d= -f2
+
+tasks:
+  build:
+    desc: Build multi-arch image and push to Docker Hub
+    cmds:
+      - ./bin/build.sh
+
+  build:local:
+    desc: Build image for local platform only (no push)
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose build --pull
+
+  up:
+    desc: Start the Traefik proxy (local compose)
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose up -d
+
+  down:
+    desc: Stop and remove the Traefik proxy containers
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose down
+
+  restart:
+    desc: Restart the Traefik proxy
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose restart
+
+  logs:
+    desc: Tail Traefik logs
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose logs -f traefik
+
+  shell:
+    desc: Open a shell in the Traefik container
+    cmds:
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose exec traefik sh
+
+  trust-cert:
+    desc: Install the CA certificate as a trusted root in the OS keychain
+    cmds:
+      - |
+        mkdir -p /tmp/traefik-proxy
+        TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose exec traefik \
+          cat /opt/traefik/certs/ca.crt > /tmp/traefik-proxy/ca.crt
+        if [ "$(uname -s)" = "Darwin" ]; then
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain /tmp/traefik-proxy/ca.crt
+        fi
+        rm -rf /tmp/traefik-proxy
+
+  upgrade:
+    desc: Pull latest image and restart proxy (preserves certs volume & network)
+    cmds:
+      - docker pull tobygr/traefik-proxy:latest
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose pull
+      - TRAEFIK_VERSION={{.TRAEFIK_VERSION}} docker compose up -d --force-recreate traefik
+
+  tag-latest:
+    desc: Tag the current version image as 'latest' and push to Docker Hub
+    cmds:
+      - docker tag tobygr/traefik-proxy:{{.TRAEFIK_VERSION}} tobygr/traefik-proxy:latest
+      - docker push tobygr/traefik-proxy:latest

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-traefik_version=2.11
+traefik_version=3.6.8
 
 TRAEFIK_VERSION=$traefik_version docker compose build \
     --pull \

--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -1,19 +1,52 @@
 #!/usr/bin/env sh
+set -e
 
 fqdn="${FQDN?'Missing FQDN'}"
 org="${CERTIFICATE_ORG:-Traefik Dev Proxy}"
+certs_dir="/opt/traefik/certs"
 
-if [[ ! -f "/opt/traefik/certs/server.crt" ]] ; then
-    echo "${fqdn}"
-    openssl req -x509 -nodes -days 365 \
-        -newkey rsa:4096 \
-        -keyout /opt/traefik/certs/server.key \
-        -out /opt/traefik/certs/server.crt \
-        -subj "/O=${org}" \
-        -addext "subjectAltName = DNS:*.${fqdn}"
+cd "$certs_dir"
 
-    chmod 644 /opt/traefik/certs/server.crt
-    chmod 600 /opt/traefik/certs/server.key
+# --- Root CA (created once, long-lived) ---
+if [ ! -f ca.key ]; then
+  echo "==> Generating root CA..."
+  openssl genrsa -out ca.key 4096
+  openssl req -x509 -new -nodes \
+    -key ca.key \
+    -sha256 \
+    -days 3650 \
+    -out ca.crt \
+    -subj "/O=${org} CA/CN=${org} Root CA"
+  chmod 600 ca.key
+  chmod 644 ca.crt
+  echo "==> Root CA generated."
+fi
+
+# --- Server cert (regenerate if missing or FQDN changed) ---
+current_fqdn=""
+[ -f server.fqdn ] && current_fqdn=$(cat server.fqdn)
+
+if [ ! -f server.crt ] || [ "$current_fqdn" != "$fqdn" ]; then
+  echo "==> Generating server certificate for *.${fqdn}..."
+  openssl genrsa -out server.key 4096
+  openssl req -new \
+    -key server.key \
+    -out server.csr \
+    -subj "/O=${org}/CN=*.${fqdn}"
+  openssl x509 -req \
+    -in server.csr \
+    -CA ca.crt \
+    -CAkey ca.key \
+    -CAcreateserial \
+    -out server.crt \
+    -days 730 \
+    -sha256 \
+    -extfile <(printf "subjectAltName=DNS:*.%s,DNS:%s" "$fqdn" "$fqdn")
+  rm server.csr
+  chmod 600 server.key
+  chmod 644 server.crt
+  echo "$fqdn" > server.fqdn
+  echo "==> Server certificate generated."
 fi
 
 exec /entrypoint.original.sh "$@"

--- a/docker/traefik/etc/traefik/traefik.yaml
+++ b/docker/traefik/etc/traefik/traefik.yaml
@@ -1,4 +1,3 @@
-# Docker configuration backend
 providers:
   docker:
     exposedByDefault: false
@@ -6,7 +5,6 @@ providers:
     directory: /etc/traefik/dynamic_config
     watch: true
 
-# API and dashboard configuration
 api:
   dashboard: true
   insecure: true
@@ -17,12 +15,11 @@ entryPoints:
     http:
       redirections:
         entryPoint:
-          # Redirect all http requests to https
           to: https
+          scheme: https
   https:
     address: ':443'
-  http3:
-    address: ':443/udp'
+    http3: {}
 
 log:
   level: DEBUG

--- a/setup
+++ b/setup
@@ -41,6 +41,9 @@ set -x
 
 project_name="${name}-traefik-proxy"
 
+docker pull "${proxy_image_name}"
+docker pull "${whoami_image_name}"
+
 cat <<EOF | docker compose -f /dev/stdin -p "${project_name}" up -d
 version: '3'
 
@@ -105,7 +108,7 @@ echo
 echo "Adding certificate as trustRoot to keychain"
 
 testForCertFile () {
-  docker compose -p "${project_name}" exec traefik ls -als | grep -q server.crt
+  docker compose -p "${project_name}" exec traefik ls -als | grep -q ca.crt
   return
 }
 
@@ -135,9 +138,9 @@ fi
 set -x
 
 mkdir /tmp/traefik-proxy || true
-cert_file="/tmp/traefik-proxy/server.crt"
+cert_file="/tmp/traefik-proxy/ca.crt"
 
-docker compose -p "${project_name}" exec traefik cat /opt/traefik/certs/server.crt > "${cert_file}"
+docker compose -p "${project_name}" exec traefik cat /opt/traefik/certs/ca.crt > "${cert_file}"
 
 set +x
 
@@ -168,7 +171,7 @@ case "$(uname -s)" in
       echo "${system_trust_certificate_directory?'Unknown platform type'}" > /dev/null || exit 1
       set -x
 
-      org_name=$(docker compose -p "${project_name}" exec traefik sh -c "openssl x509 -in server.crt -noout -subject -nameopt multiline | grep organizationName | sed -n 's/ *organizationName *= //p'")
+      org_name=$(docker compose -p "${project_name}" exec traefik sh -c "openssl x509 -in /opt/traefik/certs/ca.crt -noout -subject -nameopt multiline | grep organizationName | sed -n 's/ *organizationName *= //p'")
       cert_filename="${org_name}.crt"
 
       sudo cp "${cert_file}" "${system_trust_certificate_directory}/${cert_filename}" || (echo "Unable to copy certificate to trust store" && exit 1)


### PR DESCRIPTION
## Summary

- **Traefik v3.6.8** — bump version in `bin/build.sh` and add `TRAEFIK_VERSION` to `.env.dist`
- **traefik.yaml v3 compatibility** — remove the separate `http3` entrypoint; enable HTTP/3 inline on the `https` entrypoint; add explicit `scheme: https` to the HTTP→HTTPS redirect
- **Local CA certificate chain** — rewrite `entrypoint.sh` to generate a long-lived root CA (10 yr) on first start, then sign short-lived server certs (2 yr) from it. Only the CA cert needs to be trusted in the OS keychain; server certs rotate freely (e.g. on FQDN change) without re-trusting
- **Upgrade-safe setup script** — `docker pull` before `docker compose up -d`; cert-wait/extraction targets `ca.crt` instead of `server.crt`
- **Taskfile** — developer/maintainer workflow tasks: `build`, `build:local`, `up`, `down`, `restart`, `logs`, `shell`, `trust-cert`, `upgrade`, `tag-latest`

## Upgrade path (v2 → v3)

Old certs volume has `server.crt` (self-signed) but no `ca.key`. New `entrypoint.sh` detects the missing `ca.key`, generates a fresh CA + server cert, and the setup script installs `ca.crt` as the new trusted root. No manual cleanup required; the old self-signed cert in the keychain is inert.

## v2 → v3 label compatibility note

Most existing `Host()` rules work unchanged. Watch for:
- `Headers()`/`HeadersRegexp()` → rename to `Header()`/`HeaderRegexp()`
- Path params like `` Path(`/foo/{id}`) `` → use `PathRegexp()` instead

## Test plan

- [ ] Fresh install: `wget -O - .../setup | sh` — padlock green, cert issued by "Traefik Dev Proxy CA"
- [ ] Verify CA chain: `openssl verify -CAfile ca.crt server.crt` → `OK`
- [ ] Upgrade from v2: re-run setup on old volume — `ca.key`/`ca.crt` created, browser trusts new chain
- [ ] Cert volume preserved on `task upgrade` — CA fingerprint unchanged before/after
- [ ] FQDN change: `ca.crt` unchanged, `server.crt` re-issued for new domain
- [ ] Taskfile: `task build:local`, `task up`, `task logs`, `task trust-cert`, `task down`, `task upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)